### PR TITLE
Switch to Github latest release

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ RUN \
     FREECAD_URL=$(curl -sX GET "https://api.github.com/repos/FreeCAD/FreeCAD/releases/latest" | jq -r '.assets[] | select(.name | contains("Linux") and contains("x86_64")) | select(.name | contains("SHA256") | not) | .browser_download_url'); \
   else \
     ASSETS_URL=$(curl -sX GET "https://api.github.com/repos/FreeCAD/FreeCAD/releases/tags/${FREECAD_VERSION}" | jq -r '.assets_url'); \
-    FREECAD_URL=$(curl -sX GET "$ASSETS_URL" | jq -r '.[] | select(.name | contains("Linux") and contains("x86_64") and (contains("SHA256") | not)) | .browser_download_url'); \
+    FREECAD_URL=$(curl -sX GET "$ASSETS_URL" | jq -r '.[] | select(.name | contains("Linux") and contains("x86_64") and (contains("SHA256") | not) and (contains(".zsync") | not)) | .browser_download_url'); \
   fi && \
   echo "Downloading FreeCAD from: ${FREECAD_URL}" && \
   cd /tmp && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,14 +13,24 @@ ENV TITLE=FreeCAD
 RUN \
   echo "**** add icon ****" && \
   curl -o \
-    /kclient/public/icon.png \
-    https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/freecad-logo.png && \
-  echo "**** install packages ****" && \
-  apt-get update && \
-  apt-get install -y --no-install-recommends \
-    freecad \
-    python3-pyside2.qtwebchannel \
-    python3-pyside2.qtwebengine* && \
+  /usr/share/icons/hicolor/48x48/apps/freecad.png \
+  https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/freecad-logo.png
+RUN \
+  echo " install freecad from appimage " && \
+  if [ -z ${FREECAD_VERSION+x} ]; then \
+    FREECAD_URL=$(curl -sX GET "https://api.github.com/repos/FreeCAD/FreeCAD/releases/latest" | jq -r '.assets[] | select(.name | contains("Linux") and contains("x86_64")) | select(.name | contains("SHA256") | not) | .browser_download_url'); \
+  else \
+    ASSETS_URL=$(curl -sX GET "https://api.github.com/repos/FreeCAD/FreeCAD/releases/tags/${FREECAD_VERSION}" | jq -r '.assets_url'); \
+    FREECAD_URL=$(curl -sX GET "$ASSETS_URL" | jq -r '.[] | select(.name | contains("Linux") and contains("x86_64") and (contains("SHA256") | not)) | .browser_download_url'); \
+  fi && \
+  echo "Downloading FreeCAD from: ${FREECAD_URL}" && \
+  cd /tmp && \
+  curl -o /tmp/freecad.app -L ${FREECAD_URL} && \
+  chmod +x /tmp/freecad.app && \
+  ./freecad.app --appimage-extract && \
+  mv squashfs-root /opt/freecad && \
+  ln -s /opt/freecad/AppRun /usr/bin/freecad &&  \
+  sed -i 's|</applications>|  <application title="FreeCAD*" type="normal">\n    <maximized>yes</maximized>\n  </application>\n</applications>|' /etc/xdg/openbox/rc.xml && \
   echo "**** cleanup ****" && \
   apt-get autoclean && \
   rm -rf \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -21,7 +21,7 @@ RUN \
     FREECAD_URL=$(curl -sX GET "https://api.github.com/repos/FreeCAD/FreeCAD/releases/latest" | jq -r '.assets[] | select(.name | contains("Linux") and contains("aarch64")) | select(.name | contains("SHA256") | not) | .browser_download_url'); \
   else \
     ASSETS_URL=$(curl -sX GET "https://api.github.com/repos/FreeCAD/FreeCAD/releases/tags/${FREECAD_VERSION}" | jq -r '.assets_url'); \
-    FREECAD_URL=$(curl -sX GET "$ASSETS_URL" | jq -r '.[] | select(.name | contains("Linux") and contains("aarch64") and (contains("SHA256") | not)) | .browser_download_url'); \
+    FREECAD_URL=$(curl -sX GET "$ASSETS_URL" | jq -r '.[] | select(.name | contains("Linux") and contains("aarch64") and (contains("SHA256") | not) and (contains(".zsync") | not)) | .browser_download_url'); \
   fi && \
   echo "Downloading FreeCAD from: ${FREECAD_URL}" && \
   cd /tmp && \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -13,14 +13,23 @@ ENV TITLE=FreeCAD
 RUN \
   echo "**** add icon ****" && \
   curl -o \
-    /kclient/public/icon.png \
-    https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/freecad-logo.png && \
-  echo "**** install packages ****" && \
-  apt-get update && \
-  apt-get install -y --no-install-recommends \
-    freecad \
-    python3-pyside2.qtwebchannel \
-    python3-pyside2.qtwebengine* && \
+  /usr/share/icons/hicolor/48x48/apps/freecad.png \
+  https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/freecad-logo.png
+RUN \
+  echo " install freecad from appimage " && \
+  if [ -z ${FREECAD_VERSION+x} ]; then \
+    FREECAD_URL=$(curl -sX GET "https://api.github.com/repos/FreeCAD/FreeCAD/releases/latest" | jq -r '.assets[] | select(.name | contains("Linux") and contains("aarch64")) | select(.name | contains("SHA256") | not) | .browser_download_url'); \
+  else \
+    ASSETS_URL=$(curl -sX GET "https://api.github.com/repos/FreeCAD/FreeCAD/releases/tags/${FREECAD_VERSION}" | jq -r '.assets_url'); \
+    FREECAD_URL=$(curl -sX GET "$ASSETS_URL" | jq -r '.[] | select(.name | contains("Linux") and contains("aarch64") and (contains("SHA256") | not)) | .browser_download_url'); \
+  fi && \
+  echo "Downloading FreeCAD from: ${FREECAD_URL}" && \
+  cd /tmp && \
+  curl -o /tmp/freecad.app -L ${FREECAD_URL} && \
+  chmod +x /tmp/freecad.app && \
+  ./freecad.app --appimage-extract && \
+  mv squashfs-root /opt/freecad && \
+  ln -s /opt/freecad/AppRun /usr/bin/freecad &&  \
   sed -i 's|</applications>|  <application title="FreeCAD*" type="normal">\n    <maximized>yes</maximized>\n  </application>\n</applications>|' /etc/xdg/openbox/rc.xml && \
   echo "**** cleanup ****" && \
   apt-get autoclean && \

--- a/jenkins-vars.yml
+++ b/jenkins-vars.yml
@@ -2,8 +2,7 @@
 
 # jenkins variables
 project_name: docker-freecad
-external_type: na
-custom_version_command: "curl -sX GET 'https://api.github.com/repos/FreeCAD/FreeCAD/releases/latest' | awk -F'\"' '/\"tag_name\":/{ print $4; exit }'"
+external_type: github_stable
 release_type: stable
 release_tag: latest
 ls_branch: master

--- a/jenkins-vars.yml
+++ b/jenkins-vars.yml
@@ -3,7 +3,7 @@
 # jenkins variables
 project_name: docker-freecad
 external_type: na
-custom_version_command: "curl -sX GET https://ftp.debian.org/debian/dists/bookworm/main/binary-amd64/Packages.gz | gunzip |grep -A 7 -m 1 'Package: freecad' | awk -F ': ' '/Version/{print $2;exit}' | awk -F '+' '{print $1}'"
+custom_version_command: "curl -sX GET 'https://api.github.com/repos/FreeCAD/FreeCAD/releases/latest' | awk -F'\"' '/\"tag_name\":/{ print $4; exit }'"
 release_type: stable
 release_tag: latest
 ls_branch: master


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]


<!--- Before submitting a pull request please check the following -->

<!---  If this is a fix for a typo (in code, documentation, or the README) please file an issue and let us sort it out. We do not need a PR  -->
<!---  Ask yourself if this modification is something the whole userbase will benefit from, if this is a specific change for corner case functionality or plugins please look at making a Docker Mod or local script  https://blog.linuxserver.io/2019/09/14/customizing-our-containers/ -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!--- We maintain a changelog of major revisions to the container at the end of readme-vars.yml in the root of this repository, please add your changes there if appropriate -->


<!--- Coding guidelines: -->
<!--- 1. Installed packages in the Dockerfiles should be in alphabetical order -->
<!--- 2. Changes to Dockerfile should be replicated in Dockerfile.armhf and Dockerfile.aarch64 if applicable -->
<!--- 3. Indentation style (tabs vs 4 spaces vs 1 space) should match the rest of the document -->
<!--- 4. Readme is auto generated from readme-vars.yml, make your changes there -->

------------------------------

 - [ yes ] I have read the [contributing](https://github.com/linuxserver/docker-freecad/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description:
<!--- Describe your changes in detail -->

Switch away from debian package (still outdated at 0.20.2) to the github appimage release.

## Benefits of this PR and context:
<!--- Please explain why we should accept this PR. If this fixes an outstanding bug, please reference the issue # -->
In short, currently it provides Freecad 1.0 which is much improved over 0.20.2

Updated to always point to the "latest" release by default. However I did test and it is possible to use 0.20.2 as a build arg to build 0.20.2 as an example. The weekly release I think will only work, if they contain an asset for x86_64 or aarch64 which sometimes for me didn't work.

So, unlike PR #6 this does not have the release hardcoded. I used the orcaslicer repo for inspiration.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
Built the latest version using command:
```
sudo docker build --pull -t lscr.io/linuxserver/freecad:latest .
[+] Building 187.2s (9/9) FINISHED                                                                                    docker:default
 => [internal] load build definition from Dockerfile                                                                            0.0s
 => => transferring dockerfile: 1.86kB                                                                                          0.0s
 => [internal] load metadata for ghcr.io/linuxserver/baseimage-kasmvnc:debianbookworm                                           1.0s
 => [internal] load .dockerignore                                                                                               0.0s
 => => transferring context: 2B                                                                                                 0.0s
 => [1/4] FROM ghcr.io/linuxserver/baseimage-kasmvnc:debianbookworm@sha256:95f38d7a3e4b3fff3ceffca10029b5f227c26c49e2ad9d6d9  100.2s
 => => resolve ghcr.io/linuxserver/baseimage-kasmvnc:debianbookworm@sha256:95f38d7a3e4b3fff3ceffca10029b5f227c26c49e2ad9d6d9ea  0.0s
 => => sha256:95f38d7a3e4b3fff3ceffca10029b5f227c26c49e2ad9d6d9ea0cf1abb93f8f4 1.61kB / 1.61kB                                  0.0s
 => => sha256:b670f148d66d3a8ed91a7e801f190abeca727ad667892c4175d94360c46a6637 2.39kB / 2.39kB                                  0.0s
 => => sha256:c26e55e577302828e50ed3cfedf76bf2f0ab51c41e5f7c8c0b04da3d73adb593 31.53MB / 31.53MB                                3.5s
 => => sha256:92fc290345a0d705aeb69ffc81c3bd74172d00226634c1c9e4a350795654f8f8 17.27kB / 17.27kB                                0.0s
 => => sha256:c0f8eff906b8b4379c387842515be0c1cca71b1826474bd58a4f4e3018ed9b9c 6.21kB / 6.21kB                                  0.6s
 => => sha256:149b11207ddc1518f3e6e7edfe7b55f940831f88b473c835db158d9135fcd769 1.36kB / 1.36kB                                  0.6s
 => => sha256:3b19f8671f7f5c6b835a23c9f6057d89c16fd66303326ab8d72e2203a33adfe2 429B / 429B                                      1.1s
 => => sha256:0d0a23f7e8cde2ef576cd27e08158fbb5de25f94004434bf12a020880bbb25e9 705B / 705B                                      1.1s
 => => sha256:908b06508210d32ec96d3f6020ab5297bb2b80b276a1f21d6a9dcc81de64cc26 18.98MB / 18.98MB                                4.7s
 => => sha256:8b1a68978b6c63f097b88bf79f231bef19fea8d86cf0ab6a277cf1818e47b104 3.92kB / 3.92kB                                  1.7s
 => => sha256:c771bbb0026511cce601be8173e053a00c568bc0ea9dee4809552b63d2d3dea7 2.57MB / 2.57MB                                  4.2s
 => => sha256:a9339642bebf2365160ca5bffa7436fa9aaa18561bfdaeaabcba91f402f46491 20.58MB / 20.58MB                                6.9s
 => => extracting sha256:c26e55e577302828e50ed3cfedf76bf2f0ab51c41e5f7c8c0b04da3d73adb593                                       2.5s
 => => sha256:12c11a0747a25fe4612a682c7d3a24d36c5153f382b1079cf8cf22ef48695a0c 819.71MB / 819.71MB                             70.3s
 => => sha256:cb4f7800cc5138152552f9dd14777b700946987cb5b66776d78d74fa37f7d258 14.20kB / 14.20kB                                5.3s
 => => extracting sha256:c0f8eff906b8b4379c387842515be0c1cca71b1826474bd58a4f4e3018ed9b9c                                       0.0s
 => => extracting sha256:149b11207ddc1518f3e6e7edfe7b55f940831f88b473c835db158d9135fcd769                                       0.0s
 => => extracting sha256:0d0a23f7e8cde2ef576cd27e08158fbb5de25f94004434bf12a020880bbb25e9                                       0.0s
 => => extracting sha256:3b19f8671f7f5c6b835a23c9f6057d89c16fd66303326ab8d72e2203a33adfe2                                       0.0s
 => => extracting sha256:908b06508210d32ec96d3f6020ab5297bb2b80b276a1f21d6a9dcc81de64cc26                                       1.1s
 => => extracting sha256:8b1a68978b6c63f097b88bf79f231bef19fea8d86cf0ab6a277cf1818e47b104                                       0.0s
 => => extracting sha256:c771bbb0026511cce601be8173e053a00c568bc0ea9dee4809552b63d2d3dea7                                       0.4s
 => => extracting sha256:a9339642bebf2365160ca5bffa7436fa9aaa18561bfdaeaabcba91f402f46491                                       1.1s
 => => extracting sha256:12c11a0747a25fe4612a682c7d3a24d36c5153f382b1079cf8cf22ef48695a0c                                      29.2s
 => => extracting sha256:cb4f7800cc5138152552f9dd14777b700946987cb5b66776d78d74fa37f7d258                                       0.0s
 => [internal] load build context                                                                                               0.0s
 => => transferring context: 143B                                                                                               0.0s
 => [2/4] RUN   echo "**** add icon ****" &&   curl -o   /usr/share/icons/hicolor/48x48/apps/freecad.png   https://raw.githubu  0.9s
 => [3/4] RUN   echo " install freecad from appimage " &&   if [ -z ${FREECAD_VERSION+x} ]; then     FREECAD_URL=$(curl -sX G  66.8s
 => [4/4] COPY /root /                                                                                                          0.1s
 => exporting to image                                                                                                         18.1s
 => => exporting layers                                                                                                        18.0s
 => => writing image sha256:29bdce73f8e1e506f950c6c006bad7794a5e317a94eb6d839ece182074525275                                    0.0s
 => => naming to lscr.io/linuxserver/freecad:latest                                                                             0.0s
 ```
 
 Then stopped my container, deleted it and used docker compose to load it up. I then browsed to the url to confirm version 1.0.0 is installed and usable.

docker-compse:
```
  freecad:
    image: lscr.io/linuxserver/freecad:latest
    container_name: freecad
    security_opt:
      - seccomp:unconfined #optional
    environment:
      - PUID=${PUID}
      - PGID=${PGID}
      - TZ=${TZ}
      - DRINODE=/dev/dri/renderD128  # Specify the Intel GPU rendering device
    volumes:
      - /mnt/tank/docker/apps/freecad:/config
      - /mnt/tank/docker/apps/nextcloud/html/data/tinuva/files:/Files
    devices:
      - /dev/dri:/dev/dri  # Mount the DRI devices into the container
    #ports:
    #  - 3000:3000
    #  - 3001:3001
    restart: unless-stopped
    labels:
      - "traefik.http.routers.freecad-secure.middlewares=basic-auth@file" #basic-auth@file #oauth@file
      - "traefik.enable=true"
      - "traefik.http.routers.freecad-secure.tls=true"
      - "traefik.http.services.freecad.loadbalancer.server.port=3000"
```


<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

In the browser, it looks like this:
![Screenshot 2025-05-13 at 7 04 25 PM](https://github.com/user-attachments/assets/4ab6a949-4564-4881-afc4-f1509b42c717)


Tested the version ARG with:
```
sudo docker build --build-arg FREECAD_VERSION="0.20.2" --no-cache --pull -t lscr.io/linuxserver/freecad:0.20.2 .
```
This also worked in the browser showing the expected version is installed.


## Source / References:
<!--- Please include any forum posts/github links relevant to the PR -->
Closes #4 
