### PR TITLE
make wayland default

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,9 @@ LABEL build_version="Linuxserver.io version:- ${VERSION} Build-date:- ${BUILD_DA
 LABEL maintainer="thelamer"
 
 # title
-ENV TITLE=FreeCAD
+ENV TITLE=FreeCAD \
+    NO_GAMEPAD=true \
+    PIXELFLUX_WAYLAND=true
 
 RUN \
   echo "**** add icon ****" && \

--- a/README.md
+++ b/README.md
@@ -612,6 +612,7 @@ Once registered you can define the dockerfile to use with `-f Dockerfile.aarch64
 
 ## Versions
 
+* **29.03.26:** - Make Wayland default disable with PIXELFLUX_WAYLAND=false.
 * **28.12.25:** - Add Wayland init logic.
 * **22.09.25:** - Rebase to Debian Trixie.
 * **02.07.25:** - Rebase to Selkies, HTTPS is now required! Ingest from current appimage.

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -110,6 +110,7 @@ init_diagram: |
   "freecad:latest" <- Base Images
 # changelog
 changelogs:
+  - {date: "29.03.26:", desc: "Make Wayland default disable with PIXELFLUX_WAYLAND=false."}
   - {date: "28.12.25:", desc: "Add Wayland init logic."}
   - {date: "22.09.25:", desc: "Rebase to Debian Trixie."}
   - {date: "02.07.25:", desc: "Rebase to Selkies, HTTPS is now required! Ingest from current appimage."}

--- a/root/defaults/autostart
+++ b/root/defaults/autostart
@@ -1,1 +1,1 @@
-xterm -e /opt/freecad/AppRun
+/opt/freecad/AppRun

--- a/root/defaults/autostart_wayland
+++ b/root/defaults/autostart_wayland
@@ -1,1 +1,1 @@
-foot -e /opt/freecad/AppRun
+/opt/freecad/AppRun

--- a/root/defaults/menu.xml
+++ b/root/defaults/menu.xml
@@ -2,6 +2,6 @@
 <openbox_menu xmlns="http://openbox.org/3.4/menu">
 <menu id="root-menu" label="MENU">
 <item label="xterm" icon="/usr/share/pixmaps/xterm-color_48x48.xpm"><action name="Execute"><command>/usr/bin/xterm</command></action></item>
-<item label="FreeCAD" icon="/opt/freecad/usr/share/icons/hicolor/64x64/apps/org.freecad.FreeCAD.png"><action name="Execute"><command>xterm -e /opt/freecad/AppRun</command></action></item>
+<item label="FreeCAD" icon="/opt/freecad/usr/share/icons/hicolor/64x64/apps/org.freecad.FreeCAD.png"><action name="Execute"><command>/opt/freecad/AppRun</command></action></item>
 </menu>
 </openbox_menu>

--- a/root/defaults/menu_wayland.xml
+++ b/root/defaults/menu_wayland.xml
@@ -2,6 +2,6 @@
 <openbox_menu xmlns="http://openbox.org/3.4/menu">
 <menu id="root-menu" label="MENU">
 <item label="foot" icon="/usr/share/icons/hicolor/48x48/apps/foot.png"><action name="Execute"><command>/usr/bin/foot</command></action></item>
-<item label="FreeCAD" icon="/opt/freecad/usr/share/icons/hicolor/64x64/apps/org.freecad.FreeCAD.png"><action name="Execute"><command>foot -e /opt/freecad/AppRun</command></action></item>
+<item label="FreeCAD" icon="/opt/freecad/usr/share/icons/hicolor/64x64/apps/org.freecad.FreeCAD.png"><action name="Execute"><command>/opt/freecad/AppRun</command></action></item>
 </menu>
 </openbox_menu>


### PR DESCRIPTION
Wayland default cutover, also removed terminal wrapping the app as that was only needed because the gamepad interposer was enabled. 